### PR TITLE
Revert sortable on spill -- to avoid accidental initiative reorder

### DIFF
--- a/src/hud/tracker.ts
+++ b/src/hud/tracker.ts
@@ -587,6 +587,7 @@ class PF2eHudTracker extends PF2eHudBase<TrackerSettings> {
                 draggable: ".combatant",
                 dataIdAttr: "data-combatant-id",
                 easing: "cubic-bezier(1, 0, 0, 1)",
+                revertOnSpill: true,
                 onEnd: (event) => this.#onSortableEnd(event),
                 onUpdate: (event) => this.#onSortableUpdate(event),
             });


### PR DESCRIPTION
As discussed in discord - https://discord.com/channels/880968862240239708/1113543255754285178/1273246450607980574

Before & after visible on discord (gif files too big for this)

