### PR TITLE
Fix encounter tracker using first cached xp award

### DIFF
--- a/src/hud/tracker.ts
+++ b/src/hud/tracker.ts
@@ -965,7 +965,7 @@ function buildMetrics(metrics: EncounterPF2e["metrics"] | null): TrackerContext[
                 threat)}}</span>
         </div>
         <div>
-            ${localize("tracker.award", metrics.award)} *
+            {{localize 'pf2e-hud.tracker.award' xp=award.xp}} *
         </div>
         <div>
             {{localize 'PF2E.Encounter.Metrics.Budget' spent=budget.spent max=budget.max


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/0e828ead-c862-4759-b9d3-a96d1d139dc1

After:

https://github.com/user-attachments/assets/facdf45d-e7eb-4ede-b8e2-bd0c00f30832

