### PR TITLE
Enable image upload in avatar editor and shortcut popup

### DIFF
--- a/src/avatar-editor/application.ts
+++ b/src/avatar-editor/application.ts
@@ -96,7 +96,7 @@ class AvatarEditor extends foundry.applications.api.ApplicationV2 {
             callback: (path: string) => {
                 this.#setImage(path as ImageFilePath | VideoFilePath);
             },
-            allowUpload: false,
+            allowUpload: true,
             type: "imagevideo",
             current: this.#data.src || this.actor.img,
         }).render({ force: true });

--- a/src/hud/popup/shortcut.ts
+++ b/src/hud/popup/shortcut.ts
@@ -71,7 +71,7 @@ class ShortcutPopup extends ItemHudPopup {
                         callback: (path) => {
                             input.value = path;
                         },
-                        allowUpload: false,
+                        allowUpload: true,
                         type: "image",
                         current: input?.value || this.shortcut.usedImage,
                     }).render({ force: true });


### PR DESCRIPTION
- Changed allowUpload from false to true in avatar editor application
- Changed allowUpload from false to true in shortcut popup
- Allows users to upload custom images for avatars and shortcuts